### PR TITLE
add ldap-scim-bridge chart in builds

### DIFF
--- a/build.json
+++ b/build.json
@@ -267,6 +267,14 @@
         "commitURL": "https://github.com/wireapp/wire-account/commit/7fce1076525d276a91c2d6a85eebf5595bf0272b",
         "commit": "7fce1076525d276a91c2d6a85eebf5595bf0272b"
       }
+    },
+    "ldap-scim-bridge": {
+      "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-develop",
+      "version": "4.41.68",
+      "meta": {
+        "commit": "b33b5d197167c847960a9dbd4e8c3166c164ef7e",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/b33b5d197167c847960a9dbd4e8c3166c164ef7e"
+      }
     }
   }
 }


### PR DESCRIPTION
Add ldap-scim-bridge chart to ship in the offline artifact.