### PR TITLE
Revert "Bump wire-server charts to 5.15.0"

### DIFF
--- a/build.json
+++ b/build.json
@@ -20,202 +20,202 @@
     },
     "wire-server": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "redis-ephemeral": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "redis-cluster": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "rabbitmq": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "rabbitmq-external": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "databases-ephemeral": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "fake-aws": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "fake-aws-s3": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "fake-aws-sqs": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "aws-ingress": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "fluent-bit": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "kibana": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "backoffice": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "calling-test": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "demo-smtp": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "elasticsearch-curator": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "elasticsearch-external": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "elasticsearch-ephemeral": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "minio-external": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "cassandra-external": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "nginx-ingress-controller": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "ingress-nginx-controller": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "nginx-ingress-services": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "reaper": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "restund": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "coturn": {
@@ -236,10 +236,10 @@
     },
     "k8ssandra-test-cluster": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "postgresql": {
@@ -270,10 +270,10 @@
     },
     "ldap-scim-bridge": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     },
     "smallstep-accomp": {
@@ -318,10 +318,10 @@
     },
     "wire-server-enterprise": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "5.15.0",
+      "version": "5.14.0",
       "meta": {
-        "commit": "b55cd63e0fa588ced3089051261ab11f7d92f916",
-        "commitURL": "https://github.com/wireapp/wire-server/commit/b55cd63e0fa588ced3089051261ab11f7d92f916"
+        "commit": "d357e54751abad14fbf07bfaa3ec8d8e44b87e1f",
+        "commitURL": "https://github.com/wireapp/wire-server/commit/d357e54751abad14fbf07bfaa3ec8d8e44b87e1f"
       }
     }
   }


### PR DESCRIPTION
This will be deployed tomorrow.