### PR TITLE
q2-2025: upgrade sft and coturn 

### DIFF
--- a/build.json
+++ b/build.json
@@ -29,10 +29,10 @@
     },
     "sftd": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-avs",
-      "version": "0.122.0",
+      "version": "0.130.0",
       "meta": {
-        "appVersion": "4.1.45",
-        "commit": "469b138"
+        "appVersion": "5.0.60",
+        "commit": "60165de"
       }
     },
     "aws-ingress": {
@@ -69,10 +69,10 @@
     },
     "coturn": {
       "repo": "https://s3-eu-west-1.amazonaws.com/public.wire.com/charts",
-      "version": "4.6.2-federation-wireapp.34",
+      "version": "4.6.2-federation-wireapp.43",
       "meta": {
-        "commit": "17df8c2463f5d321036a4bae50fb6a12b0aca11d",
-        "commitURL": "https://github.com/wireapp/coturn/commit/17df8c2463f5d321036a4bae50fb6a12b0aca11d"
+        "commit": "93fca851fad09ad3cea2fedd12c34ed90b215b45",
+        "commitURL": "https://github.com/wireapp/coturn/commit/93fca851fad09ad3cea2fedd12c34ed90b215b45"
       }
     },
     "databases-ephemeral": {


### PR DESCRIPTION
to a version not dependent on non-longer-pullable bitnami images.

part of https://wearezeta.atlassian.net/browse/WPB-20787
