### PR TITLE
WPB-25763: On prem firs oci charts 

### DIFF
--- a/bin/publish-oci-chart
+++ b/bin/publish-oci-chart
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 #
-# Usage: GITHUB_USER=<user> GITHUB_TOKEN=<pat> ./bin/publish-oci-chart [chart-name [version]]
+# Usage: REGISTRY_USER=<user> REGISTRY_TOKEN=<token> ./bin/publish-oci-chart [chart-name [version]]
 #
-# Publishes Helm charts from build.json to GitHub Container Registry as OCI charts.
+# Publishes Helm charts from build.json to an OCI registry.
 # Charts to publish are listed in oci-charts.txt (one chart name per line).
 # Charts already present in the registry at the current version are skipped.
 #
@@ -11,23 +11,29 @@
 # With a chart name, processes that single chart regardless of oci-charts.txt.
 # With a chart name and version, skips the existence check and force-publishes.
 #
+# Environment variables:
+#   REGISTRY_USER   Registry username (required)
+#   REGISTRY_TOKEN  Registry password / token (required)
+#   OCI_REGISTRY    Full registry path (default: quay.io/wire/charts)
+#
 # Requires: helm >= 3.8, jq
 
 set -euo pipefail
 
-GITHUB_USER=${GITHUB_USER:?"Set GITHUB_USER environment variable"}
-GITHUB_TOKEN=${GITHUB_TOKEN:?"Set GITHUB_TOKEN environment variable"}
+REGISTRY_USER=${REGISTRY_USER:?"Set REGISTRY_USER environment variable"}
+REGISTRY_TOKEN=${REGISTRY_TOKEN:?"Set REGISTRY_TOKEN environment variable"}
+OCI_REGISTRY=${OCI_REGISTRY:-"quay.io/wire/charts"}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_JSON="${SCRIPT_DIR}/../build.json"
 CHARTS_LIST="${SCRIPT_DIR}/../oci-charts.txt"
 
-OCI_REGISTRY="ghcr.io/${GITHUB_USER}/wire-charts"
+REGISTRY_HOST="${OCI_REGISTRY%%/*}"
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-echo "Logging into ghcr.io ..."
-echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u "$GITHUB_USER" --password-stdin
+echo "Logging into ${REGISTRY_HOST} ..."
+echo "$REGISTRY_TOKEN" | helm registry login "$REGISTRY_HOST" -u "$REGISTRY_USER" --password-stdin
 
 publish_chart() {
   local chart_name=$1

--- a/bin/publish-oci-chart
+++ b/bin/publish-oci-chart
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+#
+# Usage: GITHUB_USER=<user> GITHUB_TOKEN=<pat> ./bin/publish-oci-chart [chart-name [version]]
+#
+# Publishes Helm charts from build.json to GitHub Container Registry as OCI charts.
+# Charts to publish are listed in oci-charts.txt (one chart name per line).
+# Charts already present in the registry at the current version are skipped.
+#
+# With no arguments, processes all charts in oci-charts.txt.
+# With a chart name, processes that single chart regardless of oci-charts.txt.
+# With a chart name and version, skips the existence check and force-publishes.
+#
+# Requires: helm >= 3.8, jq
+
+set -euo pipefail
+
+GITHUB_USER=${GITHUB_USER:?"Set GITHUB_USER environment variable"}
+GITHUB_TOKEN=${GITHUB_TOKEN:?"Set GITHUB_TOKEN environment variable"}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_JSON="${SCRIPT_DIR}/../build.json"
+CHARTS_LIST="${SCRIPT_DIR}/../oci-charts.txt"
+
+OCI_REGISTRY="ghcr.io/${GITHUB_USER}/wire-charts"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Logging into ghcr.io ..."
+echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u "$GITHUB_USER" --password-stdin
+
+publish_chart() {
+  local chart_name=$1
+  local force=${2:-}
+
+  local version
+  version=$(jq -r ".helmCharts[\"${chart_name}\"].version" "$BUILD_JSON")
+  local repo
+  repo=$(jq -r ".helmCharts[\"${chart_name}\"].repo" "$BUILD_JSON")
+
+  if [[ "$version" == "null" || "$repo" == "null" ]]; then
+    echo "  SKIP: ${chart_name} not found in build.json"
+    return
+  fi
+
+  if [[ -z "$force" ]] && helm show chart "oci://${OCI_REGISTRY}/${chart_name}" --version "$version" &>/dev/null; then
+    echo "  SKIP: ${chart_name}:${version} already exists in registry"
+    return
+  fi
+
+  echo "  Downloading ${chart_name} ${version} from ${repo} ..."
+  helm pull "$chart_name" --repo "$repo" --version "$version" --destination "$TMP_DIR"
+
+  echo "  Pushing to oci://${OCI_REGISTRY} ..."
+  helm push "${TMP_DIR}/${chart_name}-${version}.tgz" "oci://${OCI_REGISTRY}"
+  rm -f "${TMP_DIR}/${chart_name}-${version}.tgz"
+
+  echo "  Published: oci://${OCI_REGISTRY}/${chart_name}:${version}"
+}
+
+if [[ $# -gt 0 ]]; then
+  chart=$1
+  force=${2:-}
+  echo ""
+  echo "==> ${chart}"
+  if [[ -n "$force" ]]; then
+    # Version override provided — skip existence check, use override version
+    repo=$(jq -r ".helmCharts[\"${chart}\"].repo" "$BUILD_JSON")
+    echo "  Downloading ${chart} ${force} from ${repo} ..."
+    helm pull "$chart" --repo "$repo" --version "$force" --destination "$TMP_DIR"
+    echo "  Pushing to oci://${OCI_REGISTRY} ..."
+    helm push "${TMP_DIR}/${chart}-${force}.tgz" "oci://${OCI_REGISTRY}"
+    echo "  Published: oci://${OCI_REGISTRY}/${chart}:${force}"
+  else
+    publish_chart "$chart"
+  fi
+else
+  if [[ ! -f "$CHARTS_LIST" ]]; then
+    echo "Error: ${CHARTS_LIST} not found. Create it with one chart name per line." >&2
+    exit 1
+  fi
+
+  while IFS= read -r chart || [[ -n "$chart" ]]; do
+    [[ -z "$chart" || "$chart" == \#* ]] && continue
+    echo ""
+    echo "==> ${chart}"
+    publish_chart "$chart"
+  done < "$CHARTS_LIST"
+fi
+
+echo ""
+echo "Done."

--- a/oci-charts.txt
+++ b/oci-charts.txt
@@ -1,0 +1,10 @@
+# Charts to publish to OCI registry (ghcr.io).
+# One chart name per line. Names must match keys in build.json.
+# Lines starting with # are ignored.
+
+wire-server
+webapp
+team-settings
+account-pages
+sftd
+coturn


### PR DESCRIPTION
Stefan:

```
# Usage: REGISTRY_USER=<user> REGISTRY_TOKEN=<token> WIRE_CHANNEL=<channel> WIRE_BUILD_JSON=<path> ./bin/publish-oci-chart <chart-name> [version]
#
# Publishes a Helm chart from build.json to an OCI registry.
# Charts already present in the registry at the current version are skipped.
#
# With a chart name, publishes that chart.
# With a chart name and version, uses the override version instead of build.json.
#
# Environment variables:
#   REGISTRY_USER    Registry username (required)
#   REGISTRY_TOKEN   Registry password / token (required)
#   WIRE_CHANNEL     Release channel (required)
#   WIRE_BUILD_JSON  Path to build.json (required)
#   OCI_REGISTRY     Full registry path (default: quay.io/wire/${WIRE_CHANNEL}/charts)
```